### PR TITLE
PHP 8.2 Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,4 +45,4 @@ jobs:
       # Runs a set of commands using the runners shell
       - name: PHPCS
         run: |
-          ./vendor/bin/phpcs --standard=psr2 --runtime-set ignore_warnings_on_exit true --report=summary sources
+          ./vendor/bin/phpcs --standard=psr12 --runtime-set ignore_warnings_on_exit true --report=summary sources

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,14 @@ jobs:
       - name: Build
         run: |
           composer install --dev
-      - name: Setup PHP
+      - name: Setup PHP 8.1
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.1'
+      - name: Setup PHP 8.2
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
       - name: PHPStan Static Analysis
         uses: php-actions/phpstan@v2
         with:

--- a/sources/lib/Configurator/DatabaseCollectorConfigurator.php
+++ b/sources/lib/Configurator/DatabaseCollectorConfigurator.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of Pomm's SymfonyBidge package.
  *

--- a/sources/lib/Controller/PommProfilerController.php
+++ b/sources/lib/Controller/PommProfilerController.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of Pomm's SymfonyBidge package.
  *
@@ -15,7 +16,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-
 use PommProject\Foundation\Pomm;
 use Twig\Environment;
 

--- a/sources/lib/DatabaseDataCollector.php
+++ b/sources/lib/DatabaseDataCollector.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of Pomm's SymfonyBidge package.
  *
@@ -12,7 +13,6 @@ namespace PommProject\SymfonyBridge;
 
 use PommProject\Foundation\Exception\SqlException;
 use PommProject\Foundation\Session\Session;
-
 use Symfony\Component\Stopwatch\Stopwatch;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;

--- a/sources/lib/PropertyInfo/Extractor/ListExtractor.php
+++ b/sources/lib/PropertyInfo/Extractor/ListExtractor.php
@@ -43,7 +43,7 @@ class ListExtractor implements PropertyListExtractorInterface
             $session = $this->pomm->getDefaultSession();
         }
 
-        $model_name = $context['model:name'] ?? "${class}Model";
+        $model_name = $context['model:name'] ?? "{$class}Model";
 
         if (!class_exists($model_name)) {
             return null;

--- a/sources/lib/PropertyInfo/Extractor/ListExtractor.php
+++ b/sources/lib/PropertyInfo/Extractor/ListExtractor.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of Pomm's SymfonyBidge package.
  *

--- a/sources/lib/PropertyInfo/Extractor/TypeExtractor.php
+++ b/sources/lib/PropertyInfo/Extractor/TypeExtractor.php
@@ -45,7 +45,7 @@ class TypeExtractor implements PropertyTypeExtractorInterface
             $session = $this->pomm->getDefaultSession();
         }
 
-        $model_name = $context['model:name'] ?? "${class}Model";
+        $model_name = $context['model:name'] ?? "{$class}Model";
 
         if (!class_exists($model_name)) {
             return null;

--- a/sources/lib/PropertyInfo/Extractor/TypeExtractor.php
+++ b/sources/lib/PropertyInfo/Extractor/TypeExtractor.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of Pomm's SymfonyBidge package.
  *

--- a/sources/lib/Serializer/Normalizer/FlexibleEntityDenormalizer.php
+++ b/sources/lib/Serializer/Normalizer/FlexibleEntityDenormalizer.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of Pomm's SymfonyBidge package.
  *

--- a/sources/lib/Serializer/Normalizer/FlexibleEntityNormalizer.php
+++ b/sources/lib/Serializer/Normalizer/FlexibleEntityNormalizer.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of Pomm's SymfonyBidge package.
  *


### PR DESCRIPTION
PHP 8.2 Support : 
- Remove deprecated `${class}`
- Add CI Action PHP 8.2